### PR TITLE
Reduce redux calls and drag/resize controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5739,7 +5739,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6104,7 +6105,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6152,6 +6154,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6190,11 +6193,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9957,6 +9962,17 @@
         }
       }
     },
+    "parcel-plugin-web-extension": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/parcel-plugin-web-extension/-/parcel-plugin-web-extension-1.5.2.tgz",
+      "integrity": "sha512-qcxcEi6lA9+3sLA3TgMcfddTHrxIQXBhwdM12JxEEEhmxz4FIw9JqaOq+GNQQ2EHAiEQ6Amb7I+YE+NGOx9BXQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/fs": "^1.11.0",
+        "fast-glob": "^2.2.2",
+        "parcel-bundler": "^1.9.0"
+      }
+    },
     "parchment": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
@@ -11829,6 +11845,11 @@
         "refetch": "^0.2.4"
       }
     },
+    "re-resizable": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.11.0.tgz",
+      "integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
+    },
     "react": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
@@ -12095,6 +12116,15 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-draggable": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.1.1.tgz",
+      "integrity": "sha512-tqIgDUm4XPSFbxelYpcsnayPU79P26ChnszDl5/RDFKfMuHnRxypS+OFfEyAEO1CtqaB3lrecQ2dyNIE2G0TlQ==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-error-overlay": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.5.tgz",
@@ -12195,6 +12225,16 @@
         "lodash-es": "^4.17.11",
         "prop-types": "^15.6.2",
         "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "react-rnd": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-9.1.2.tgz",
+      "integrity": "sha512-XmJVy/xjbSttpKZynnB1WM3woWhDjb719iOIRRvPkEf61Trw4DBJS38VHxIsBClNX6JXCbZFi6yUXC1SxKIkDQ==",
+      "requires": {
+        "re-resizable": "4.11.0",
+        "react-draggable": "3.1.1",
+        "tslib": "1.9.3"
       }
     },
     "react-scripts": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "react-dom": "^16.6.0",
     "react-redux": "^5.1.0",
     "react-resize-detector": "^3.2.1",
+    "react-rnd": "^9.1.2",
     "react-scripts": "2.1.0",
     "redux": "^4.0.1",
     "styled-components": "^4.0.2"
   },
   "scripts": {
-    "start" : "parcel manifest.json -d dist",
-    "build" : "parcel build manifest.json -d build",
+    "start": "parcel manifest.json -d dist",
+    "build": "parcel build manifest.json -d build",
     "start:update": "cp -r ./src/assets ./dist/.",
     "build:update": "cp -r ./src/assets ./build/.",
     "make": "zip -r app.zip build/",

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -10,8 +10,7 @@ class Note extends Component {
 
     this.sizeOfComponent = React.createRef();
 
-  
-    console.log("Color of note: " + this.props.color);
+    // console.log("Color of note: " + this.props.color);
     // Using a local state to assist in moving dem
     this.state = {
       currentX: this.props.position.x,
@@ -42,11 +41,7 @@ class Note extends Component {
       // Only update the global store when it has stopped moving
       if (!nextProps.dataDrag.isMoving && this.props.dataDrag.isMoving) {
         // Update the global store
-        this.props.onPositionChange(
-          this.props.id,
-          this.state.currentX,
-          this.state.currentY
-        );
+        // console.log("positon changing");
       }
     }
   }
@@ -67,12 +62,7 @@ class Note extends Component {
         width: this.sizeOfComponent.current.clientWidth,
         height: this.sizeOfComponent.current.clientHeight
       });
-
-      this.props.onSizeChange(
-        this.props.id,
-        this.state.width,
-        this.state.height
-      );
+      // console.log("size changing");
     }
   }
 
@@ -90,6 +80,22 @@ class Note extends Component {
               height: this.state.height
             }}
             ref={this.sizeOfComponent}
+            onMouseUp={() => {
+              // console.log("YOU RELEASED THE MOUSE$#@$!$@!#%!%");
+
+              // console.log("UPDATING POS AND SIZE IN REDUX")
+              this.props.onSizeChange(
+                this.props.id,
+                this.state.width,
+                this.state.height
+              );
+
+              this.props.onPositionChange(
+                this.props.id,
+                this.state.currentX,
+                this.state.currentY
+              );
+            }}
           >
             <div
               className="title-bar"
@@ -99,7 +105,7 @@ class Note extends Component {
                 className="title-input"
                 placeholder="Note"
                 defaultValue={this.props.title}
-                style={{ color: this.state.ContrastingColor}}
+                style={{ color: this.state.ContrastingColor }}
                 onClick={() => {
                   this.setState({
                     colorPickerVisible: false
@@ -110,7 +116,7 @@ class Note extends Component {
                   // console.log("The mouse is down");
                 }}
                 onMouseUp={() => {
-                  // console.log("the mouse is up");
+                  // console.log("the mouse is upppppp!!%$#^$#@%#@!%!");
                 }}
                 onMouseMove={() => {
                   // console.log("the mouse is moving");
@@ -121,7 +127,7 @@ class Note extends Component {
               <Icon
                 type="bg-colors"
                 className="nav-bar-item-color"
-                style={{color: this.state.ContrastingColor}}
+                style={{ color: this.state.ContrastingColor }}
                 onClick={() => {
                   // console.log("you clicked the color button");
                   this.setState({
@@ -132,7 +138,7 @@ class Note extends Component {
 
               <Icon
                 className="nav-bar-item-delete"
-                style={{color: this.state.ContrastingColor}}
+                style={{ color: this.state.ContrastingColor }}
                 type="delete"
                 onClick={this.props.onDeleteClick}
               />
@@ -158,13 +164,17 @@ class Note extends Component {
                 onChangeComplete={(color, event) => {
                   // Calculate contrasting color
                   // Thanks goes to casesandberg on github for this formula from the heavens
-                  const yiq = ((color.rgb.r * 299) + (color.rgb.g * 587) + (color.rgb.b * 114)) / 1000
-                  const CC = (yiq >= 128) ? '#000' : '#fff'
+                  const yiq =
+                    (color.rgb.r * 299 +
+                      color.rgb.g * 587 +
+                      color.rgb.b * 114) /
+                    1000;
+                  const CC = yiq >= 128 ? "#000" : "#fff";
                   this.props.onColorChange(color.hex, CC);
-                  
+
                   this.setState({
                     ContrastingColor: CC
-                  })
+                  });
                 }}
               />
             )}
@@ -180,9 +190,10 @@ var draggableNote = clickdrag(Note, {
   onDragStop: () => {
     // update the state of the position of this note here
     // and size
+    // console.log("You stopped dragging, lets update the size");
   },
   onDragStart: () => {
-    console.log("dragging");
+    // console.log("dragging");
   },
   getSpecificEventData: e => ({
     ctrl: e.ctrlKey,

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-// import clickdrag from "react-clickdrag";
+import { LightenColor } from "../utils/LightenColor";
 import { NoteContainer } from "../elements/NoteContainer";
 import { Icon } from "antd";
 import { BlockPicker } from "react-color";
@@ -10,9 +10,10 @@ class Note extends Component {
     super(props);
 
     this.sizeOfComponent = React.createRef();
+    let accent = LightenColor(this.props.color, -0.05);
 
-    // console.log("Color of note: " + this.props.color);
-    // Using a local state to assist in moving dem
+    console.log("Your accent color is: " + accent);
+
     this.state = {
       currentX: this.props.position.x,
       currentY: this.props.position.y,
@@ -21,7 +22,8 @@ class Note extends Component {
       colorPickerVisible: false,
       width: this.props.size.width,
       height: this.props.size.height,
-      ContrastingColor: this.props.contrastColor
+      ContrastingColor: this.props.contrastColor,
+      accentColor: accent
     };
   }
 
@@ -61,7 +63,10 @@ class Note extends Component {
       >
         <NoteContainer>
           <div className="note" ref={this.sizeOfComponent}>
-            <div className="note-drag-handle" />
+            <div
+              className="note-drag-handle"
+              style={{ backgroundColor: this.state.accentColor }}
+            />
             <div
               className="title-bar"
               style={{ backgroundColor: this.props.color }}
@@ -135,6 +140,13 @@ class Note extends Component {
                   this.setState({
                     ContrastingColor: CC
                   });
+
+                  // Calculate the accent color
+                  let accent = LightenColor(color.hex, -0.05);
+
+                  this.setState({
+                    accentColor: accent
+                  })
                 }}
               />
             )}

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -48,10 +48,6 @@ class Note extends Component {
           let tempWidth = this.state.width + delta.width;
           let tempHeight = this.state.height + delta.height;
 
-          console.log(
-            "updating size width: " + tempWidth + " height: " + tempHeight
-          );
-
           this.setState({
             width: tempWidth,
             height: tempHeight
@@ -59,6 +55,7 @@ class Note extends Component {
 
           this.props.onSizeChange(tempWidth, tempHeight);
         }}
+        dragHandleClassName="title-bar"
         minWidth={200}
         minHeight={200}
         bounds="window"

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react";
-import clickdrag from "react-clickdrag";
+// import clickdrag from "react-clickdrag";
 import { NoteContainer } from "../elements/NoteContainer";
-import { Icon, Button } from "antd";
+import { Icon } from "antd";
 import { BlockPicker } from "react-color";
+import { Rnd } from "react-rnd";
 
 class Note extends Component {
   constructor(props) {
@@ -24,79 +25,46 @@ class Note extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    // If its moving and the control key is down, update the state
-    if (nextProps.dataDrag.isMoving && nextProps.dataDrag.ctrl) {
-      this.setState({
-        currentX: this.state.lastPositionX + nextProps.dataDrag.moveDeltaX,
-        currentY: this.state.lastPositionY + nextProps.dataDrag.moveDeltaY
-      });
-    } else {
-      // Update the local state for changes
-      this.setState({
-        lastPositionX: this.state.currentX,
-        lastPositionY: this.state.currentY
-      });
-
-      // Only update the global store when it has stopped moving
-      if (!nextProps.dataDrag.isMoving && this.props.dataDrag.isMoving) {
-        // Update the global store
-        // console.log("positon changing");
-      }
-    }
-  }
-
-  componentDidUpdate() {
-    // globalWidth = this.sizeOfComponent.current.clientWidth;
-    // globalHeight = this.sizeOfComponent.current.clientHeight;
-
-    // console.log("Width: " + globalWidth);
-    // console.log("Height: " + globalHeight);
-
-    // check to see if the size has changed
-    if (
-      this.state.width != this.sizeOfComponent.current.clientWidth ||
-      this.state.height != this.sizeOfComponent.current.clientHeight
-    ) {
-      this.setState({
-        width: this.sizeOfComponent.current.clientWidth,
-        height: this.sizeOfComponent.current.clientHeight
-      });
-      // console.log("size changing");
-    }
-  }
 
   render() {
     return (
-      <div>
+      <Rnd
+        default={{
+          x: this.state.currentX,
+          y: this.state.currentY,
+          width: this.state.width,
+          height: this.state.height
+        }}
+        onDragStop={(e, d) => {
+          console.log("x: " + d.x + " y: " + d.y);
+          this.setState({
+            currentX: d.x,
+            currentY: d.y
+          });
+
+          this.props.onPositionChange(this.props.id, d.x, d.y);
+        }}
+        onResizeStop={(e, d, ref, delta, position) => {
+          let tempWidth = this.state.width + delta.width;
+          let tempHeight = this.state.height + delta.height;
+
+          console.log(
+            "updating size width: " + tempWidth + " height: " + tempHeight
+          );
+
+          this.setState({
+            width: tempWidth,
+            height: tempHeight
+          });
+
+          this.props.onSizeChange(tempWidth, tempHeight);
+        }}
+        minWidth={200}
+        minHeight={200}
+        bounds="window"
+      >
         <NoteContainer>
-          <div
-            className="note"
-            style={{
-              transform: `translate(${this.state.currentX}px, ${
-                this.state.currentY
-              }px)`,
-              width: this.state.width,
-              height: this.state.height
-            }}
-            ref={this.sizeOfComponent}
-            onMouseUp={() => {
-              // console.log("YOU RELEASED THE MOUSE$#@$!$@!#%!%");
-
-              // console.log("UPDATING POS AND SIZE IN REDUX")
-              this.props.onSizeChange(
-                this.props.id,
-                this.state.width,
-                this.state.height
-              );
-
-              this.props.onPositionChange(
-                this.props.id,
-                this.state.currentX,
-                this.state.currentY
-              );
-            }}
-          >
+          <div className="note" ref={this.sizeOfComponent}>
             <div
               className="title-bar"
               style={{ backgroundColor: this.props.color }}
@@ -112,15 +80,8 @@ class Note extends Component {
                   });
                 }}
                 onChange={this.props.onTitleChange}
-                onMouseDown={() => {
-                  // console.log("The mouse is down");
-                }}
-                onMouseUp={() => {
-                  // console.log("the mouse is upppppp!!%$#^$#@%#@!%!");
-                }}
-                onMouseMove={() => {
-                  // console.log("the mouse is moving");
-                  // console.log(event);
+                onMouseDown={e => {
+                  e.stopPropagation();
                 }}
               />
 
@@ -129,7 +90,6 @@ class Note extends Component {
                 className="nav-bar-item-color"
                 style={{ color: this.state.ContrastingColor }}
                 onClick={() => {
-                  // console.log("you clicked the color button");
                   this.setState({
                     colorPickerVisible: true
                   });
@@ -150,6 +110,9 @@ class Note extends Component {
                 this.setState({
                   colorPickerVisible: false
                 });
+              }}
+              onMouseDown={e => {
+                e.stopPropagation();
               }}
               onDoubleClick={() => {
                 // console.log("you clicked twice nigga!");
@@ -180,25 +143,9 @@ class Note extends Component {
             )}
           </div>
         </NoteContainer>
-      </div>
+      </Rnd>
     );
   }
 }
 
-// // Make the note draggable
-var draggableNote = clickdrag(Note, {
-  onDragStop: () => {
-    // update the state of the position of this note here
-    // and size
-    // console.log("You stopped dragging, lets update the size");
-  },
-  onDragStart: () => {
-    // console.log("dragging");
-  },
-  getSpecificEventData: e => ({
-    ctrl: e.ctrlKey,
-    shift: e.shiftKey
-  })
-});
-
-export default draggableNote;
+export default Note;

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -25,7 +25,6 @@ class Note extends Component {
     };
   }
 
-
   render() {
     return (
       <Rnd
@@ -46,7 +45,7 @@ class Note extends Component {
         }}
         onResizeStop={(e, d, ref, delta, position) => {
           let tempWidth = this.state.width + delta.width;
-          let tempHeight = this.state.height + delta.height;
+          let tempHeight = this.state.height + delta.height + 20;
 
           this.setState({
             width: tempWidth,
@@ -55,13 +54,14 @@ class Note extends Component {
 
           this.props.onSizeChange(tempWidth, tempHeight);
         }}
-        dragHandleClassName="title-bar"
+        dragHandleClassName="note-drag-handle"
         minWidth={200}
         minHeight={200}
         bounds="window"
       >
         <NoteContainer>
           <div className="note" ref={this.sizeOfComponent}>
+            <div className="note-drag-handle" />
             <div
               className="title-bar"
               style={{ backgroundColor: this.props.color }}

--- a/src/components/NoteList.js
+++ b/src/components/NoteList.js
@@ -58,9 +58,9 @@ const NoteList = ({
               onColorChange(note.id, color, contrastColor);
             }}
 
-            onSizeChange={(id, x, y) => {
+            onSizeChange={(x, y) => {
               // console.log("The size has changed to: " + x + ", " +  y)
-              onSizeChange(id, x, y);
+              onSizeChange(note.id, x, y);
             }}
           />
         );
@@ -126,6 +126,8 @@ const mapDispatchToProps = dispatch => ({
   },
 
   onPositionChange: (id, x, y) => {
+    console.log("The position has changed x: " + x + " y: " + y);
+
     dispatch(updateNotePosition(id, x, y, PAGE));
   },
 

--- a/src/elements/NoteContainer.js
+++ b/src/elements/NoteContainer.js
@@ -1,10 +1,15 @@
 import styled from "styled-components";
 
 export const NoteContainer = styled.div`
-  width: 300px;
-  height: 400px;
+  /* width: 300px; */
+  /* height: 400px; */
 
   overflow: visible;
+
+  .note-drag-handle {
+    width:100%;
+    height: 20px;
+  }
 
   .note {
     position: absolute;

--- a/src/elements/NoteContainer.js
+++ b/src/elements/NoteContainer.js
@@ -1,14 +1,14 @@
 import styled from "styled-components";
 
 export const NoteContainer = styled.div`
-  /* width: 300px; */
-  /* height: 400px; */
-
   overflow: visible;
 
   .note-drag-handle {
     width:100%;
     height: 20px;
+    background-color: blue;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
   }
 
   .note {
@@ -19,7 +19,7 @@ export const NoteContainer = styled.div`
     height: 100%;
 
     background-color: #f4f4f4;
-    border-radius: 5px;
+    border-radius: 5px, 5px,0px, 0px;
     resize: both;
     overflow: auto;
 
@@ -57,8 +57,8 @@ export const NoteContainer = styled.div`
     height: 60px;
 
     background-color: #35a1ec;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+    /* border-top-left-radius: 5px; */
+    /* border-top-right-radius: 5px; */
   }
 
   .title-input::placeholder {
@@ -86,7 +86,7 @@ export const NoteContainer = styled.div`
   .note-input {
     position: absolute;
     box-sizing: border-box;
-    top: 60px;
+    top: 80px;
     left: 0;
     right: 0;
     bottom: 0;

--- a/src/elements/NoteContainer.js
+++ b/src/elements/NoteContainer.js
@@ -8,10 +8,10 @@ export const NoteContainer = styled.div`
 
   .note {
     position: absolute;
-    top: 300px;
-    left: 300px;
-    width: 300px;
-    height: 400px;
+    /* top: 300px; */
+    /* left: 300px; */
+    width: 100%;
+    height: 100%;
 
     background-color: #f4f4f4;
     border-radius: 5px;
@@ -74,6 +74,7 @@ export const NoteContainer = styled.div`
     padding-left: 20px;
     color: #f4f4f4;
     border: none;
+    user-select: none;
     /*   border: solid 1px black;; */
   }
 

--- a/src/utils/LightenColor.js
+++ b/src/utils/LightenColor.js
@@ -1,0 +1,17 @@
+export const LightenColor = (color, luminosity) => {
+    // validate hex string
+	color = new String(color).replace(/[^0-9a-f]/gi, '');
+	if (color.length < 6) {
+		color = color[0]+ color[0]+ color[1]+ color[1]+ color[2]+ color[2];
+	}
+	luminosity = luminosity || 0;
+
+	// convert to decimal and change luminosity
+	let newColor = "#", c, i, black = 0, white = 255;
+	for (i = 0; i < 3; i++) {
+		c = parseInt(color.substr(i*2,2), 16);
+		c = Math.round(Math.min(Math.max(black, c + (luminosity * white)), white)).toString(16);
+		newColor += ("00"+c).substr(c.length);
+	}
+	return newColor; 
+}


### PR DESCRIPTION
With this PR two things happened. I reduced the calls to redux to only when the note stops moving. I also updated the resize and drag. Now the drag only happens when you click below the buttons and resizing happens on any size. See image to view area. 
![image](https://user-images.githubusercontent.com/28901411/58645688-12f73280-82c1-11e9-86a3-70cd2622014e.png)
#2 #34 

I have added a bar for handling dragging. Right now is it just blue. I want to add a function that will calculate a little bit darker color from the note color to distinguish the bar.

 I mostly want to verify this works